### PR TITLE
Support m3u files from twitch.tv

### DIFF
--- a/m3u.go
+++ b/m3u.go
@@ -71,11 +71,12 @@ func Parse(r io.Reader) (Playlist, error) {
       if i < 0 {
         return pl, fmt.Errorf("unexpected line: %q", line)
       }
-      time, err := strconv.ParseInt(line[8:i+8], 10, 64)
+      ftime, err := strconv.ParseFloat(line[8:i+8], 64)
 
       if err != nil {
         return pl, err
       }
+      time := int64(ftime)
       path, err := br.ReadString('\n')
 
       if err != nil {


### PR DESCRIPTION
Twitch.tv outputs m3u files where the time duration of tracks has a fractional part, it's possible that they are violating the standard on that but this change is helpful for me.
